### PR TITLE
Replaced OnPreDraw with measure to fix slow List Scrolling and overall smoothness

### DIFF
--- a/library/src/com/tjerkw/slideexpandable/library/AbstractSlideExpandableListAdapter.java
+++ b/library/src/com/tjerkw/slideexpandable/library/AbstractSlideExpandableListAdapter.java
@@ -1,12 +1,9 @@
 package com.tjerkw.slideexpandable.library;
 
-import android.util.Log;
 import android.util.SparseIntArray;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewTreeObserver;
 import android.view.animation.Animation;
-import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.ListAdapter;
 
@@ -108,6 +105,8 @@ public abstract class AbstractSlideExpandableListAdapter extends WrapperListAdap
 	public void enableFor(View parent, int position) {
 		View more = getExpandToggleButton(parent);
 		View itemToolbar = getExpandableView(parent);
+		itemToolbar.measure(parent.getWidth(), parent.getHeight());
+		
 		enableFor(more, itemToolbar, position);
 	}
 
@@ -124,22 +123,8 @@ public abstract class AbstractSlideExpandableListAdapter extends WrapperListAdap
 		}
 		int height = viewHeights.get(position, -1);
 		if(height == -1) {
-
-			// just before drawing we know that the measurement
-			// was done correctly, so at this point we remember the height
-			// of the target view, so we know it when animating
-			target.getViewTreeObserver().addOnPreDrawListener(
-				new ViewTreeObserver.OnPreDrawListener() {
-					@Override
-					public boolean onPreDraw() {
-						target.getViewTreeObserver().removeOnPreDrawListener(this);
-						Log.d("AbstractSlideExpandable", "gotHeight: " + target.getHeight());
-						viewHeights.put(position, target.getHeight());
-						updateExpandable(target, position);
-						return false;
-					}
-				}
-			);
+			viewHeights.put(position, target.getMeasuredHeight());
+			updateExpandable(target,position);
 		} else {
 			updateExpandable(target, position);
 		}

--- a/library/src/com/tjerkw/slideexpandable/library/ExpandCollapseAnimation.java
+++ b/library/src/com/tjerkw/slideexpandable/library/ExpandCollapseAnimation.java
@@ -30,7 +30,7 @@ public class ExpandCollapseAnimation extends Animation {
 	public ExpandCollapseAnimation(View view, int type) {
 
 		mAnimatedView = view;
-		mEndHeight = mAnimatedView.getHeight();
+		mEndHeight = mAnimatedView.getMeasuredHeight();
 		mLayoutParams = ((LinearLayout.LayoutParams) view.getLayoutParams());
 		mType = type;
 		if(mType == EXPAND) {

--- a/library/src/com/tjerkw/slideexpandable/library/SlideExpandableListAdapter.java
+++ b/library/src/com/tjerkw/slideexpandable/library/SlideExpandableListAdapter.java
@@ -1,7 +1,6 @@
 package com.tjerkw.slideexpandable.library;
 
 import android.view.View;
-import android.widget.Button;
 import android.widget.ListAdapter;
 
 /**


### PR DESCRIPTION
I deduced that my slow list scrolling was due to OnPreDraw having to be called when you scrolled through the list the first time before the listener was removed. Since we already have the parent view with the correct dimensions in enableFor() we can just do a measurement call to find out the height of our hidden view and add it to the stack. This removes the overhead from OnPreDraw and still keeps the Min API Level at 1.
