### PR TITLE
Close open items

### DIFF
--- a/library/src/com/tjerkw/slideexpandable/library/AbstractSlideExpandableListAdapter.java
+++ b/library/src/com/tjerkw/slideexpandable/library/AbstractSlideExpandableListAdapter.java
@@ -177,7 +177,7 @@ public abstract class AbstractSlideExpandableListAdapter extends WrapperListAdap
 	}
 
 	/**
-	 * Performs eithe COLLAPSE or EXPAND animation on the target view
+	 * Performs either COLLAPSE or EXPAND animation on the target view
 	 * @param target the view to animate
 	 * @param type the animation type, either ExpandCollapseAnimation.COLLAPSE
 	 *             or ExpandCollapseAnimation.EXPAND
@@ -189,5 +189,16 @@ public abstract class AbstractSlideExpandableListAdapter extends WrapperListAdap
 		);
 		anim.setDuration(getAnimationDuration());
 		target.startAnimation(anim);
+	}
+	
+
+	/**
+	 * closes the current open item with an animation
+	 */
+	public void animateCollapse() {
+		if(lastOpen != null){
+			animateView(lastOpen, ExpandCollapseAnimation.COLLAPSE);
+			lastOpenPosition = -1;
+		}
 	}
 }

--- a/library/src/com/tjerkw/slideexpandable/library/SlideExpandableListView.java
+++ b/library/src/com/tjerkw/slideexpandable/library/SlideExpandableListView.java
@@ -25,6 +25,10 @@ class SlideExpandableListView extends ListView {
 		super(context, attrs, defStyle);
 	}
 
+	public void collapse() {
+		final SlideExpandableListAdapter adapter = (SlideExpandableListAdapter) getAdapter();
+		adapter.animateCollapse();
+	}
 
 	public void setAdapter(ListAdapter adapter) {
 		super.setAdapter(new SlideExpandableListAdapter(adapter));


### PR DESCRIPTION
The Listview can now close the current open element of the adapter.

There was no functionality to close the current open item. The only way was to know which item is open and then get the expand button and run performClick().
