### PR TITLE
fixed bug collapse current open View

### DIFF
--- a/library/src/com/tjerkw/slideexpandable/library/AbstractSlideExpandableListAdapter.java
+++ b/library/src/com/tjerkw/slideexpandable/library/AbstractSlideExpandableListAdapter.java
@@ -199,6 +199,8 @@ public abstract class AbstractSlideExpandableListAdapter extends WrapperListAdap
 		if(lastOpen != null){
 			animateView(lastOpen, ExpandCollapseAnimation.COLLAPSE);
 			lastOpenPosition = -1;
+			viewHeights.clear();
+			openItems.clear();
 		}
 	}
 }


### PR DESCRIPTION
sry, but in my last commit was a little bug

after changing the cursor of a list the recently closed view gets
recreated with an open expandable. The open item was still saved.
