### PR TITLE
ClassCastException on Specific Adapter Cast's

### DIFF
--- a/library/src/com/tjerkw/slideexpandable/library/WrapperListAdapterImpl.java
+++ b/library/src/com/tjerkw/slideexpandable/library/WrapperListAdapterImpl.java
@@ -3,6 +3,7 @@ package com.tjerkw.slideexpandable.library;
 import android.database.DataSetObserver;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.BaseAdapter;
 import android.widget.ListAdapter;
 import android.widget.WrapperListAdapter;
 
@@ -18,7 +19,7 @@ import android.widget.WrapperListAdapter;
  * @author tjerk
  * @date 6/9/12 4:41 PM
  */
-public abstract class WrapperListAdapterImpl implements WrapperListAdapter {
+public abstract class WrapperListAdapterImpl extends BaseAdapter implements WrapperListAdapter {
 	protected ListAdapter wrapped;
 
 	public WrapperListAdapterImpl(ListAdapter wrapped) {


### PR DESCRIPTION
So I ran into a trivial error today, when ListView has to cast the Adapter it cast's it to a BaseAdapter and you implement the interface but it doesn't extend BaseAdapter. This commit is just simply including it.

If you want to see the problem in action try having a listview with enough items for Fast Scrolling to kick in and you'll see the ANR with CastClassException thrown.

Don't forget to enable fast scrolling with

```
android:fastScrollEnabled="true"
```
