### PR TITLE
Updated Animation Duration Visibility, Added Animation Duration Setter as well as isAnyItemExpanded

### DIFF
--- a/library/src/com/tjerkw/slideexpandable/library/AbstractSlideExpandableListAdapter.java
+++ b/library/src/com/tjerkw/slideexpandable/library/AbstractSlideExpandableListAdapter.java
@@ -115,9 +115,14 @@ public abstract class AbstractSlideExpandableListAdapter extends WrapperListAdap
 	 * Set's the Animation duration for the Expandable animation
 	 * 
 	 * @param duration The duration as an integer in MS (duration > 0)
+	 * @exception IllegalArgumentException if parameter is less than zero
 	 */
 	public void setAnimationDuration(int duration) {
-		if(duration > 0) animationDuration = duration;
+		if(duration < 0) {
+			throw new IllegalArgumentException("Duration is less than zero");
+		}
+		
+		animationDuration = duration;
 	}
 	/**
 	 * Check's if any position is currently Expanded


### PR DESCRIPTION
The reason's for my changes can be explained in the following example here.

``` java
adapter.collapseLastOpen();

new Handler().postDelayed(new Runnable() {
    @Override
    public void run() {
        /// Do Something after collapsed
    }
},adapter.getAnimationDuration() );
```

I want to perform an action after I collapse the last Item if there is an item that need's to be collapsed. So I check

``` java
isAnyItemExpanded()
```

If so post a delayed handler for the duration of the animation so It looks as smooth as possible afterwords. Otherwise do the operation.

My other change with the setter and getter for animationDuration is because it would be a hassle for some use cases where the user just wants to wrap the Adapter. With the current Animation Duration being the way it is with having to override it your forced to extend SlideExpandableListAdapter. With my changes the user could say for instance keep an instance variable to SlideExpandableListAdapter and set the duration when they create the adapter instead of having to extend it.

If you see anything wrong I love the criticism :+1: 
