### PR TITLE
ReLayout toolbar after measure()

### DIFF
--- a/library/src/com/tjerkw/slideexpandable/library/AbstractSlideExpandableListAdapter.java
+++ b/library/src/com/tjerkw/slideexpandable/library/AbstractSlideExpandableListAdapter.java
@@ -140,6 +140,7 @@ public abstract class AbstractSlideExpandableListAdapter extends WrapperListAdap
 		itemToolbar.measure(parent.getWidth(), parent.getHeight());
 
 		enableFor(more, itemToolbar, position);
+		itemToolbar.requestLayout();
 	}
 
 


### PR DESCRIPTION
The toolbar layout needs to be relayout after the call to measure() otherwise, for example, having centered content in the toolbar will appear as left align after stopping and restarting the activity (i.e. switching off the screen)
