### PR TITLE
Added two override method

### DIFF
--- a/library/src/com/tjerkw/slideexpandable/library/ActionSlideExpandableListView.java
+++ b/library/src/com/tjerkw/slideexpandable/library/ActionSlideExpandableListView.java
@@ -1,5 +1,6 @@
 package com.tjerkw.slideexpandable.library;
 
+import android.R;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.view.View;
@@ -7,12 +8,12 @@ import android.view.ViewGroup;
 import android.widget.ListAdapter;
 
 /**
- * A more specific expandable listview in which the expandable area
- * consist of some buttons which are context actions for the item itself.
- *
- * It handles event binding for those buttons and allow for adding
- * a listener that will be invoked if one of those buttons are pressed.
- *
+ * A more specific expandable listview in which the expandable area consist of
+ * some buttons which are context actions for the item itself.
+ * 
+ * It handles event binding for those buttons and allow for adding a listener
+ * that will be invoked if one of those buttons are pressed.
+ * 
  * @author tjerk
  * @date 6/26/12 7:01 PM
  */
@@ -28,26 +29,31 @@ public class ActionSlideExpandableListView extends SlideExpandableListView {
 		super(context, attrs);
 	}
 
-	public ActionSlideExpandableListView(Context context, AttributeSet attrs, int defStyle) {
+	public ActionSlideExpandableListView(Context context, AttributeSet attrs,
+			int defStyle) {
 		super(context, attrs, defStyle);
 	}
 
-	public void setItemActionListener(OnActionClickListener listener, int ... buttonIds) {
+	public void setItemActionListener(OnActionClickListener listener,
+			int... buttonIds) {
 		this.listener = listener;
 		this.buttonIds = buttonIds;
 	}
 
 	/**
-	 * Interface for callback to be invoked whenever an action is clicked in
-	 * the expandle area of the list item.
+	 * Interface for callback to be invoked whenever an action is clicked in the
+	 * expandle area of the list item.
 	 */
 	public interface OnActionClickListener {
 		/**
 		 * Called when an action item is clicked.
-		 *
-		 * @param itemView the view of the list item
-		 * @param clickedView the view clicked
-		 * @param position the position in the listview
+		 * 
+		 * @param itemView
+		 *            the view of the list item
+		 * @param clickedView
+		 *            the view clicked
+		 * @param position
+		 *            the position in the listview
 		 */
 		public void onClick(View itemView, View clickedView, int position);
 	}
@@ -56,26 +62,61 @@ public class ActionSlideExpandableListView extends SlideExpandableListView {
 		super.setAdapter(new WrapperListAdapterImpl(adapter) {
 
 			@Override
-			public View getView(final int position, View view, ViewGroup viewGroup) {
-				final View listView = wrapped.getView(position, view, viewGroup);
+			public View getView(final int position, View view,
+					ViewGroup viewGroup) {
+				final View listView = wrapped
+						.getView(position, view, viewGroup);
 				// add the action listeners
-				if(buttonIds != null && listView!=null) {
-					for(int id : buttonIds) {
+				if (buttonIds != null && listView != null) {
+					for (int id : buttonIds) {
 						View buttonView = listView.findViewById(id);
-						if(buttonView!=null) {
-							buttonView.findViewById(id).setOnClickListener(new OnClickListener() {
-								@Override
-								public void onClick(View view) {
-									if(listener!=null) {
-										listener.onClick(listView, view, position);
-									}
-								}
-							});
+						if (buttonView != null) {
+							buttonView.findViewById(id).setOnClickListener(
+									new OnClickListener() {
+										@Override
+										public void onClick(View view) {
+											if (listener != null) {
+												listener.onClick(listView,
+														view, position);
+											}
+										}
+									});
 						}
 					}
 				}
 				return listView;
 			}
 		});
+	}
+
+	public void setAdapter(ListAdapter adapter, int toggle_button_id,int expandable_view_id) {
+		super.setAdapter(new WrapperListAdapterImpl(adapter){
+
+			@Override
+			public View getView(final int position, View view,
+					ViewGroup viewGroup) {
+				final View listView = wrapped
+						.getView(position, view, viewGroup);
+				// add the action listeners
+				if (buttonIds != null && listView != null) {
+					for (int id : buttonIds) {
+						View buttonView = listView.findViewById(id);
+						if (buttonView != null) {
+							buttonView.findViewById(id).setOnClickListener(
+									new OnClickListener() {
+										@Override
+										public void onClick(View view) {
+											if (listener != null) {
+												listener.onClick(listView,
+														view, position);
+											}
+										}
+									});
+						}
+					}
+				}
+				return listView;
+			}
+		},toggle_button_id,expandable_view_id);
 	}
 }

--- a/library/src/com/tjerkw/slideexpandable/library/SlideExpandableListView.java
+++ b/library/src/com/tjerkw/slideexpandable/library/SlideExpandableListView.java
@@ -9,8 +9,8 @@ import android.widget.ListView;
 import android.content.Context;
 
 /**
- * Simple subclass of listview which does nothing more than wrap
- * any ListAdapter in a SlideExpandalbeListAdapter
+ * Simple subclass of listview which does nothing more than wrap any ListAdapter
+ * in a SlideExpandalbeListAdapter
  */
 class SlideExpandableListView extends ListView {
 	private SlideExpandableListAdapter adapter;
@@ -23,17 +23,18 @@ class SlideExpandableListView extends ListView {
 		super(context, attrs);
 	}
 
-	public SlideExpandableListView(Context context, AttributeSet attrs, int defStyle) {
+	public SlideExpandableListView(Context context, AttributeSet attrs,
+			int defStyle) {
 		super(context, attrs, defStyle);
 	}
 
 	/**
 	 * Collapses the currently open view.
-	 *
+	 * 
 	 * @return true if a view was collapsed, false if there was no open view.
 	 */
 	public boolean collapse() {
-		if(adapter!=null) {
+		if (adapter != null) {
 			return adapter.collapseLastOpen();
 		}
 		return false;
@@ -44,24 +45,32 @@ class SlideExpandableListView extends ListView {
 		super.setAdapter(this.adapter);
 	}
 
+	public void setAdapter(ListAdapter adapter, int toggle_button_id,
+			int expandable_view_id) {
+		this.adapter = new SlideExpandableListAdapter(adapter,
+				toggle_button_id, expandable_view_id);
+		super.setAdapter(this.adapter);
+	}
+
 	/**
-	 * Registers a OnItemClickListener for this listview which will
-	 * expand the item by default. Any other OnItemClickListener will be overriden.
-	 *
+	 * Registers a OnItemClickListener for this listview which will expand the
+	 * item by default. Any other OnItemClickListener will be overriden.
+	 * 
 	 * To undo call setOnItemClickListener(null)
-	 *
-	 * Important: This method call setOnItemClickListener, so the value will be reset
+	 * 
+	 * Important: This method call setOnItemClickListener, so the value will be
+	 * reset
 	 */
 	public void enableExpandOnItemClick() {
 		this.setOnItemClickListener(new OnItemClickListener() {
 			@Override
-			public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
-				SlideExpandableListAdapter adapter = (SlideExpandableListAdapter)getAdapter();
+			public void onItemClick(AdapterView<?> adapterView, View view,
+					int i, long l) {
+				SlideExpandableListAdapter adapter = (SlideExpandableListAdapter) getAdapter();
 				adapter.getExpandToggleButton(view).performClick();
 			}
 		});
 	}
-
 
 	@Override
 	public Parcelable onSaveInstanceState() {
@@ -70,12 +79,12 @@ class SlideExpandableListView extends ListView {
 
 	@Override
 	public void onRestoreInstanceState(Parcelable state) {
-		if(!(state instanceof AbstractSlideExpandableListAdapter.SavedState)) {
+		if (!(state instanceof AbstractSlideExpandableListAdapter.SavedState)) {
 			super.onRestoreInstanceState(state);
 			return;
 		}
 
-		AbstractSlideExpandableListAdapter.SavedState ss = (AbstractSlideExpandableListAdapter.SavedState)state;
+		AbstractSlideExpandableListAdapter.SavedState ss = (AbstractSlideExpandableListAdapter.SavedState) state;
 		super.onRestoreInstanceState(ss.getSuperState());
 
 		adapter.onRestoreInstanceState(ss);


### PR DESCRIPTION
Added two method, they are "ActionSlideExpandableListView.setAdapter" and  "SlideExpandableListView.setAdapter".
Now, you can use custom layout name,that two layout name "expandable" and "expandable_toggle_button" could be  changed,considering this widget may be widely used in activity or fragment.
So the naming should base on specification.
The original usage is like "list.setAdapter(buildDummyData());".
Now, You can use "list.setAdapter(buildDummyData (),R.id.item_layout,R.id.button_layout);".

thanks.
