### PR TITLE
Fix RuntimeException when unmarshalling data

### DIFF
--- a/library/src/com/tjerkw/slideexpandable/library/AbstractSlideExpandableListAdapter.java
+++ b/library/src/com/tjerkw/slideexpandable/library/AbstractSlideExpandableListAdapter.java
@@ -324,7 +324,6 @@ public abstract class AbstractSlideExpandableListAdapter extends WrapperListAdap
 			super.writeToParcel(out, flags);
             out.writeInt(lastOpenPosition);
             writeBitSet(out, openItems);
-
 		}
 
 		//required field that makes Parcelables from a Parcel


### PR DESCRIPTION
I noticed a bug when using the SlideExpandableListView.  The reproduction of the bug is as follows:
1. In Android OS settings, go under Developer options and enable "Do not keep activities"
2. In Android app, navigate until you get to an activity that uses the SlideExpandableListView
3. (Optional) I enabled the expansion on the list view
4. Jump directly out of the app (i.e., press home key)
5. Open the app again through the launcher or task switch

This will cause an exception similar to the following:
0 java.lang.RuntimeException: Unable to start activity ComponentInfo{REMOVEDBYAUTHOR}: java.lang.RuntimeException: Parcel android.os.Parcel@425119b: Unmarshalling unknown type code 28 at offset 452
1 at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2211)
2 at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2261)
3 at android.app.ActivityThread.access$600(ActivityThread.java:141)
4 at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1256)
5 at android.os.Handler.dispatchMessage(Handler.java:99)
6 at android.os.Looper.loop(Looper.java:137)
7 at android.app.ActivityThread.main(ActivityThread.java:5103)
8 at java.lang.reflect.Method.invokeNative(Native Method)
9 at java.lang.reflect.Method.invoke(Method.java:525)
10 at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:737)
11 at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:553)
12 at dalvik.system.NativeStart.main(Native Method)
13 Caused by: java.lang.RuntimeException: Parcel android.os.Parcel@425119b: Unmarshalling unknown type code 28 at offset 452
14 at android.os.Parcel.readValue(Parcel.java:2038)
15 at android.os.Parcel.readSparseArrayInternal(Parcel.java:2284)
16 at android.os.Parcel.readSparseArray(Parcel.java:1693)
17 at android.os.Parcel.readValue(Parcel.java:2028)
18 at android.os.Parcel.readMapInternal(Parcel.java:2255)
19 at android.os.Bundle.unparcel(Bundle.java:223)
20 at android.os.Bundle.getSparseParcelableArray(Bundle.java:1237)
21 at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:861)
22 at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:1104)
23 at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:1086)
24 at android.support.v4.app.FragmentManagerImpl.dispatchCreate(FragmentManager.java:1872)
25 at android.support.v4.app.FragmentActivity.onCreate(FragmentActivity.java:215)

After debugging, I noticed this issue is similar to that described by this SO article:
http://stackoverflow.com/questions/19672772/parcel-unmarshalling-unknown-type-code

It looks like the code in SavedState has the code for writing and reading the parcel reversed.  This patch resolves this problem.
