### PR TITLE
Added suport for animation’s listener with an example

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.8.+'
+        classpath 'com.android.tools.build:gradle:0.12.+'
     }
 }
 
@@ -11,5 +11,5 @@ apply plugin: 'android-library'
 
 android {
     compileSdkVersion 19
-    buildToolsVersion = '19.0.1'
+    buildToolsVersion = '19.1.0'
 }

--- a/library/src/main/java/com/tjerkw/slideexpandable/library/ExpandCollapseAnimation.java
+++ b/library/src/main/java/com/tjerkw/slideexpandable/library/ExpandCollapseAnimation.java
@@ -53,7 +53,7 @@ public class ExpandCollapseAnimation extends Animation {
 			} else {
 				mLayoutParams.bottomMargin = - (int) (mEndHeight * interpolatedTime);
 			}
-			Log.d("ExpandCollapseAnimation", "anim height " + mLayoutParams.bottomMargin);
+			//Log.d("ExpandCollapseAnimation", "anim height " + mLayoutParams.bottomMargin);
 			mAnimatedView.requestLayout();
 		} else {
 			if(mType == EXPAND) {

--- a/library/src/main/java/com/tjerkw/slideexpandable/library/SlideExpandableListAdapter.java
+++ b/library/src/main/java/com/tjerkw/slideexpandable/library/SlideExpandableListAdapter.java
@@ -25,6 +25,10 @@ public class SlideExpandableListAdapter extends AbstractSlideExpandableListAdapt
 		this(wrapped, R.id.expandable_toggle_button, R.id.expandable);
 	}
 
+    public void setExpandableSlideListener(SlideExpandableListener anSlideExpandableListener) {
+        slideListener = anSlideExpandableListener;
+    }
+
 	@Override
 	public View getExpandToggleButton(View parent) {
 		return parent.findViewById(toggle_button_id);

--- a/library/src/main/java/com/tjerkw/slideexpandable/library/SlideExpandableListener.java
+++ b/library/src/main/java/com/tjerkw/slideexpandable/library/SlideExpandableListener.java
@@ -1,0 +1,11 @@
+package com.tjerkw.slideexpandable.library;
+
+
+import android.view.View;
+
+public interface SlideExpandableListener {
+    public void onStartExpandAnimation(View view, int position);
+    public void onEndExpandAnimation(View view, int position);
+    public void onStartCollapseAnimation(View view, int position);
+    public void onEndCollapseAnimation(View view, int position);
+}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -3,11 +3,11 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.8.+'
+        classpath 'com.android.tools.build:gradle:0.12.+'
     }
 }
 
-apply plugin: 'android-library'
+apply plugin: 'com.android.application'
 
 dependencies {
     compile project(':library')
@@ -15,5 +15,5 @@ dependencies {
 
 android {
     compileSdkVersion 19
-    buildToolsVersion = '19.0.1'
+    buildToolsVersion = '19.1.0'
 }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -5,14 +5,14 @@
     android:versionName="1.0" >
 
     <uses-sdk
-        android:minSdkVersion="4"
+        android:minSdkVersion="8"
         android:targetSdkVersion="10" />
 
     <application
         android:icon="@drawable/icon"
         android:label="@string/app_name">
         <activity
-            android:name=".ExampleActivity"
+            android:name=".ChooseExample"
             android:label="@string/app_name" >
             <intent-filter >
                 <action
@@ -21,6 +21,12 @@
                     android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".ExampleAnimListenerActivity"
+            android:label="@string/app_name" />
+        <activity
+            android:name=".ExampleActivity"
+            android:label="@string/app_name" />
     </application>
 
     <supports-screens android:anyDensity="true" />

--- a/sample/src/main/java/com/tjerkw/slideexpandable/sample/ChooseExample.java
+++ b/sample/src/main/java/com/tjerkw/slideexpandable/sample/ChooseExample.java
@@ -1,0 +1,29 @@
+package com.tjerkw.slideexpandable.sample;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+
+public class ChooseExample extends Activity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.choose_activity);
+
+        findViewById(R.id.bt_example).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                startActivity(new Intent(ChooseExample.this, ExampleActivity.class));
+            }
+        });
+
+        findViewById(R.id.bt_example_listener).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                startActivity(new Intent(ChooseExample.this, ExampleAnimListenerActivity.class));
+            }
+        });
+    }
+}

--- a/sample/src/main/java/com/tjerkw/slideexpandable/sample/ExampleActivity.java
+++ b/sample/src/main/java/com/tjerkw/slideexpandable/sample/ExampleActivity.java
@@ -5,7 +5,6 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.*;
 import com.tjerkw.slideexpandable.library.ActionSlideExpandableListView;
-import com.tjerkw.slideexpandable.library.SlideExpandableListAdapter;
 
 /**
  * This example shows a expandable listview

--- a/sample/src/main/java/com/tjerkw/slideexpandable/sample/ExampleAnimListenerActivity.java
+++ b/sample/src/main/java/com/tjerkw/slideexpandable/sample/ExampleAnimListenerActivity.java
@@ -1,0 +1,74 @@
+package com.tjerkw.slideexpandable.sample;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.widget.ArrayAdapter;
+import android.widget.ListAdapter;
+import android.widget.ListView;
+
+import com.tjerkw.slideexpandable.library.SlideExpandableListAdapter;
+import com.tjerkw.slideexpandable.library.SlideExpandableListener;
+
+public class ExampleAnimListenerActivity extends Activity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.single_list_view);
+
+        ListView lv_test = (ListView) findViewById(R.id.lv_test);
+
+        //Use the wrapper expandable list adapter
+        SlideExpandableListAdapter slideAdapter = new SlideExpandableListAdapter(
+                buildDummyData(),
+                R.id.expandable_toggle_button,
+                R.id.expandable);
+
+        slideAdapter.setExpandableSlideListener(new SlideExpandableListener() {
+
+            @Override
+            public void onStartExpandAnimation(View view, int position) {
+                Log.d("slide", "start animation expand with item position: " + position);
+            }
+
+            @Override
+            public void onEndExpandAnimation(View view, int position) {
+                Log.d("slide", "end animation expand with item position:" + position);
+            }
+
+            @Override
+            public void onStartCollapseAnimation(View view, int position) {
+                Log.d("slide", "start animation collapse with item position: " + position);
+            }
+
+            @Override
+            public void onEndCollapseAnimation(View view, int position) {
+                Log.d("slide", "end animation collapse with item position: " + position);
+            }
+        });
+
+        // fill the list with data
+        lv_test.setAdapter(slideAdapter);
+    }
+
+    /**
+     * Builds dummy data for the test.
+     * In a real app this would be an adapter
+     * for your data. For example a CursorAdapter
+     */
+    public ListAdapter buildDummyData() {
+        final int SIZE = 20;
+        String[] values = new String[SIZE];
+        for(int i=0;i<SIZE;i++) {
+            values[i] = "Item "+i;
+        }
+        return new ArrayAdapter<String>(
+                this,
+                R.layout.expandable_list_item,
+                R.id.text,
+                values
+        );
+    }
+}

--- a/sample/src/main/res/layout/choose_activity.xml
+++ b/sample/src/main/res/layout/choose_activity.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <Button
+        android:id="@+id/bt_example"
+        android:layout_width="fill_parent"
+        android:text="@string/example"
+        android:layout_marginBottom="10dp"
+        android:layout_height="50dp" />
+
+    <Button
+        android:id="@+id/bt_example_listener"
+        android:layout_width="fill_parent"
+        android:text="@string/example_with_listener_animation"
+        android:layout_marginBottom="10dp"
+        android:layout_height="50dp" />
+
+</LinearLayout>

--- a/sample/src/main/res/layout/expandable_list_item.xml
+++ b/sample/src/main/res/layout/expandable_list_item.xml
@@ -1,53 +1,56 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:slide="http://schemas.android.com/apk/res/com.tjerkw.slideexpandable.library"
-              android:layout_width="fill_parent"
-              android:layout_height="wrap_content"
-              android:orientation="vertical">
-	<RelativeLayout
-			android:layout_width="fill_parent"
-			android:layout_height="wrap_content"
-			android:orientation="horizontal"
-			android:id="@+id/item">
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
 
-		<TextView
-				android:layout_width="fill_parent"
-				android:layout_height="fill_parent"
-				android:id="@+id/text"
-				android:text="Hello World" android:textSize="40dp"/>
+    <RelativeLayout
+        android:id="@+id/item"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
 
-		<Button
-				android:id="@+id/expandable_toggle_button"
-				android:text="More"
-				android:layout_width="wrap_content"
-				android:layout_height="wrap_content"
-				android:layout_alignBottom="@+id/text"
-				android:layout_alignParentRight="true"
-				android:layout_alignTop="@id/text" android:textSize="30dp"/>
+        <TextView
+            android:id="@+id/text"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:text="Hello World"
+            android:textSize="40dp" />
 
-	</RelativeLayout>
+        <Button
+            android:id="@+id/expandable_toggle_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignBottom="@+id/text"
+            android:layout_alignParentRight="true"
+            android:layout_alignTop="@id/text"
+            android:text="More"
+            android:textSize="30dp" />
 
-	<LinearLayout
-			android:layout_width="fill_parent"
-			android:layout_height="wrap_content"
-			android:orientation="horizontal"
-			android:id="@+id/expandable"
-			android:background="#000000">
+    </RelativeLayout>
 
-		<Button
-				android:id="@+id/buttonA"
-				android:layout_width="fill_parent"
-				android:layout_height="fill_parent" android:layout_weight="0.5"
-				android:text="Action A"
-				android:textSize="12dip"/>
+    <LinearLayout
+        android:id="@+id/expandable"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:background="#000000"
+        android:orientation="horizontal">
 
-		<Button
-				android:id="@+id/buttonB"
-				android:layout_width="fill_parent"
-				android:layout_height="fill_parent"
-				android:layout_weight="0.5"
-				android:text="Action B"
-				android:textSize="12dip"/>
+        <Button
+            android:id="@+id/buttonA"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:layout_weight="0.5"
+            android:text="Action A"
+            android:textSize="12dip" />
 
-	</LinearLayout>
+        <Button
+            android:id="@+id/buttonB"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:layout_weight="0.5"
+            android:text="Action B"
+            android:textSize="12dip" />
+
+    </LinearLayout>
 </LinearLayout>

--- a/sample/src/main/res/layout/single_list_view.xml
+++ b/sample/src/main/res/layout/single_list_view.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ListView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/lv_test"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content" />

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">SlideExpandable Example</string>
+    <string name="example">Example</string>
+    <string name="example_with_listener_animation">Example with listener animations</string>
 </resources>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
 include ':library'
+include ':sample'


### PR DESCRIPTION
Hi! 

I use this library frequently and I think it’s really useful. But something I’ve missed so far it’s a group of callbacks to listening for when a row is expanding or collapsing (starting or ending). For that reason, I’ve added a simple interface to handle it:

public interface SlideExpandableListener {
    public void onStartExpandAnimation(View view, int position);
    public void onEndExpandAnimation(View view, int position);
    public void onStartCollapseAnimation(View view, int position);
    public void onEndCollapseAnimation(View view, int position);
}

This interface could be implemented and linked to an instance of SlideExpandableListAdapter as follow:

 slideAdapter.setExpandableSlideListener(new SlideExpandableListener() {

```
        @Override
        public void onStartExpandAnimation(View view, int position) {
            Log.d("slide", "start animation expand with item position: " + position);
        }

        @Override
        public void onEndExpandAnimation(View view, int position) {
            Log.d("slide", "end animation expand with item position:" + position);
        }

        @Override
        public void onStartCollapseAnimation(View view, int position) {
            Log.d("slide", "start animation collapse with item position: " + position);
        }

        @Override
        public void onEndCollapseAnimation(View view, int position) {
            Log.d("slide", "end animation collapse with item position: " + position);
        }
```

});

Also, I’ve faced a few problems trying to compile the project with the current version of Android Studio (0.8.14). So I've had to make some changes to get it to work.  

Greetings,
Victor. 
